### PR TITLE
party finder regex for dungeon/kuudra

### DIFF
--- a/regex.json
+++ b/regex.json
@@ -68,7 +68,7 @@
         "privateMessageWhiteChat": "^(?<type>\u00a7dTo|\u00a7dFrom) (?<prefix>.+): \u00a7r(?<message>\u00a77.*)(?:\u00a7r)?$",
         "limboLimiterSpawned": "You were spawned in Limbo.",
         "limboLimiterAfk": "You are AFK. Move around to return from AFK.",
-        "autoChatSwapperPartyStatus2": "^(?:You have joined (?:\\[.+] )?(?:.*) party!|Party Members(?:\\[.+] )?\\w{1,100}|(?:\\[.+] )?\\w{1,100} joined the(?:.*) party(?:.*))$",
+        "autoChatSwapperPartyStatus2": "^(?:You have joined (?:\\[.+] )?(?:.*) party!|Party Members(?:\\[.+] )?\\w{1,100}|(?:\\[.+] )?\\w{1,100} joined the(?:.*) party(?:.*)|Party Finder > .* joined the dungeon group! \\(\\w+ Level \\d+\\))$",
         "silentRemovalLeaveMessage": "(?:Friend|F|Guild|G) > (?<player>\\w{1,16}) left\\.",
         "noSpectatorCommands": "You are not allowed to use commands as a spectator!",
         "cannotShoutBeforeSkywars": "You can't shout until the game has started!",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
party finder for dungeon/kuudra

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
https://discord.com/channels/822066990423605249/1224701088490586123/1224701088490586123

## How to test
<!-- Provide steps to test this PR -->
idk join a dungeon thingy

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Support Party Finder in SkyBlock for Chat Swapper
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->