### PR TITLE
add PM short channel name regex

### DIFF
--- a/regex.json
+++ b/regex.json
@@ -88,7 +88,7 @@
         "autoPartyWarpConfirm": "Some players are still in-game, run the command again to confirm warp!",
         "tabFooterAdvertisement": "\u00a7aRanks, Boosters & MORE! \u00a7r\u00a7c\u00a7lSTORE.HYPIXEL.NET",
         "tabHeaderAdvertisement": "\u00a7bYou are playing on \u00a7r\u00a7e\u00a7lMC.HYPIXEL.NET",
-        "gameBossbarAdvertisement": "\u00a7e\u00a7lPlaying \u00a7f\u00a7l.+ \u00a7e\u00a7lon \u00a7\\S\u00a7lMC\\.HYPIXEL\\.NET\u00a7r".
+        "gameBossbarAdvertisement": "\u00a7e\u00a7lPlaying \u00a7f\u00a7l.+ \u00a7e\u00a7lon \u00a7\\S\u00a7lMC\\.HYPIXEL\\.NET\u00a7r"
     },
     "test_woverflow_value": "hi"
 }

--- a/regex.json
+++ b/regex.json
@@ -65,6 +65,8 @@
         "chatRestylerFriendPattern": "^((?:\u00a7r)?\u00a7\\w)(Friend >)",
         "chatRestylerOfficerPattern": "^((?:\u00a7r)?\u00a7\\w)(Officer >)",
         "chatRestylerStatusPattern": "^(?<type>(?:\u00a7aFriend|\u00a7a\u00a7aF|\u00a72Guild|\u00a72\u00a72G)) > (\u00a7r|\u00a7r\u00a7r){1,2}(?<player>\u00a7[\\da-f]\\w{1,16}) \u00a7r\u00a7e(?<status>(?:joined|left))\\.\u00a7r$",
+        "chatRestylerPrivateMessageToPattern": "^((?:\u00a7r)?\u00a7\\w)(To)",
+        "chatRestylerPrivateMessageToPattern": "^((?:\u00a7r)?\u00a7\\w)(From)",
         "autoChatSwapperPartyStatus": "^(?:You have been kicked from the party by (?:\\[.+] )?\\w{1,16}|(?:\\[.+] )?\\w{1,16} has disbanded the party!|You left the party\\.|You are not in a party\\.|The party was disbanded because (?:all invites expired and the party was empty|the party leader disconnected)\\.)$",
         "autoChatSwapperChannelSwap": "^You are now in the (?<channel>ALL|GUILD|OFFICER) channel$",
         "autoChatSwapperAlreadyInChannel": "You're already in this channel!",
@@ -86,7 +88,7 @@
         "autoPartyWarpConfirm": "Some players are still in-game, run the command again to confirm warp!",
         "tabFooterAdvertisement": "\u00a7aRanks, Boosters & MORE! \u00a7r\u00a7c\u00a7lSTORE.HYPIXEL.NET",
         "tabHeaderAdvertisement": "\u00a7bYou are playing on \u00a7r\u00a7e\u00a7lMC.HYPIXEL.NET",
-        "gameBossbarAdvertisement": "\u00a7e\u00a7lPlaying \u00a7f\u00a7l.+ \u00a7e\u00a7lon \u00a7\\S\u00a7lMC\\.HYPIXEL\\.NET\u00a7r"
+        "gameBossbarAdvertisement": "\u00a7e\u00a7lPlaying \u00a7f\u00a7l.+ \u00a7e\u00a7lon \u00a7\\S\u00a7lMC\\.HYPIXEL\\.NET\u00a7r".
     },
     "test_woverflow_value": "hi"
 }

--- a/regex.json
+++ b/regex.json
@@ -66,7 +66,7 @@
         "chatRestylerOfficerPattern": "^((?:\u00a7r)?\u00a7\\w)(Officer >)",
         "chatRestylerStatusPattern": "^(?<type>(?:\u00a7aFriend|\u00a7a\u00a7aF|\u00a72Guild|\u00a72\u00a72G)) > (\u00a7r|\u00a7r\u00a7r){1,2}(?<player>\u00a7[\\da-f]\\w{1,16}) \u00a7r\u00a7e(?<status>(?:joined|left))\\.\u00a7r$",
         "chatRestylerPrivateMessageToPattern": "^((?:\u00a7r)?\u00a7\\w)(To)",
-        "chatRestylerPrivateMessageToPattern": "^((?:\u00a7r)?\u00a7\\w)(From)",
+        "chatRestylerPrivateMessageFromPattern": "^((?:\u00a7r)?\u00a7\\w)(From)",
         "autoChatSwapperPartyStatus": "^(?:You have been kicked from the party by (?:\\[.+] )?\\w{1,16}|(?:\\[.+] )?\\w{1,16} has disbanded the party!|You left the party\\.|You are not in a party\\.|The party was disbanded because (?:all invites expired and the party was empty|the party leader disconnected)\\.)$",
         "autoChatSwapperChannelSwap": "^You are now in the (?<channel>ALL|GUILD|OFFICER) channel$",
         "autoChatSwapperAlreadyInChannel": "You're already in this channel!",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds short channel names for private messages

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Data from [#99](https://github.com/Polyfrost/Hytils-Reborn/pull/99)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->